### PR TITLE
implement as higher order module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
-# redux-persist-immutable-state
-Implements stateIterator, stateGetter, stateSetter and stateReconciler for an [ImmutableJS](https://facebook.github.io/immutable-js/) root state.
-
-# Dependencies
-- [redux-persist](https://www.npmjs.com/package/redux-persist)
-- [redux-persist-immutable](https://www.npmjs.com/package/redux-persist-immutable) -> If you're substate are ImmutableJS objects
+# Redux Persist Immutable
+A wrapper around redux-persist that provides  [ImmutableJS](https://facebook.github.io/immutable-js/) support.
 
 # Usage
-
+For entire api see [redux-persist docs](https://github.com/rt2zz/redux-persist). This library is a drop in replacement.
 ```
-import { persistStore } from 'redux-persist';
-import { stateIterator, stateGetter, stateSetter, 
-         stateReconciler, lastStateInit } from 'redux-persist-immutable-state';
+import { persistStore } from 'redux-persist-immutable'
 
-persistStore(state, {
-  transforms: [reduxPersistImmutable], 
-  stateIterator: stateIterator,  
-  stateGetter: stateGetter, stateSetter: stateSetter,
-  lastStateInit: lastStateInit
-});
+persistStore(state)
 ```

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/constants')

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "immutable": "^3.8.1",
-    "redux-persist": "^3.6.0-alpha1"
+    "redux-persist": "^4.0.0-alpha1",
+    "redux-persist-transform-immutable": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib dist",
     "prepublish": "npm run clean && npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "ava"
   },
   "repository": {
     "type": "git",
@@ -22,12 +22,16 @@
   "author": "Stephane Rufer <stephane.rufer@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "ava": "^0.16.0",
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "redux": "^3.5.2",
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "immutable": "^3.8.1"
+    "immutable": "^3.8.1",
+    "redux-persist": "^3.6.0-alpha1"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export * from 'redux-persist/constants';

--- a/src/index.js
+++ b/src/index.js
@@ -7,19 +7,25 @@ import {
   purgeStoredState
 } from 'redux-persist';
 
+import immutableTransform from 'redux-persist-transform-immutable'
 import * as operators from './operators';
 import { stateReconciler } from './reconciler';
 
+const extendConfig = (config) => {
+  transforms = [...config.transforms, immutableTransform]
+  return {...config, ...operators, stateReconciler, transforms}
+}
+
 const autoRehydrate = (config, ...args) => {
-  return baseAutoRehydrate({...config, stateReconciler}, ...args);
+  return baseAutoRehydrate(extendConfig(config), ...args);
 };
 
 const createPersistor = (store, config, ...args) => {
-  return baseCreatePersistor(store, {...config, ...operators}, ...args);
+  return baseCreatePersistor(store, extendConfig(config), ...args);
 };
 
 const persistStore = (store, config, ...args) => {
-  return basePersistStore(store, {...config, ...operators}, ...args);
+  return basePersistStore(store, extendConfig(config), ...args);
 };
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -1,42 +1,32 @@
-import { Map } from 'immutable';
+import {
+  autoRehydrate as baseAutoRehydrate,
+  createPersistor as baseCreatePersistor,
+  createTransform,
+  getStoredState,
+  persistStore as basePersistStore,
+  purgeStoredState
+} from 'redux-persist';
 
-export const lastStateInit = new Map();
+import * as operators from './operators';
+import { stateReconciler } from './reconciler';
 
-export function stateIterator(state, callback) {
-  return state.forEach(callback);
-}
-
-export function stateGetter(state, key) {
- return state.get(key)
+const autoRehydrate = (config, ...args) => {
+  return baseAutoRehydrate({...config, stateReconciler}, ...args);
 };
 
-export function stateSetter(state, key, value) {
- return state.set(key, value)
+const createPersistor = (store, config, ...args) => {
+  return baseCreatePersistor(store, {...config, ...operators}, ...args);
 };
 
-export function stateReconciler(state, inboundState, reducedState, logger) {
- let newState = reducedState ? reducedState : new Map();
+const persistStore = (store, config, ...args) => {
+  return basePersistStore(store, {...config, ...operators}, ...args);
+};
 
- Object.keys(inboundState).forEach((key) => {
-   // if initialState does not have key, skip auto rehydration
-   if (!state.has(key)) return
-
-   // if reducer modifies substate, skip auto rehydration
-   if (state.get('key') !== reducedState.get('key')) {
-     if (logger) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
-     newState = newState.set(key, reducedState.get(key))
-     return
-   }
-
-   // otherwise take the inboundState
-   if (state.has(key)) {
-     newState = state.merge(inboundState) // shallow merge
-   } else {
-     newState = state.set(key, inboundState[key]) // hard set
-   }
-
-   if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
- })
-
- return newState
+export {
+  autoRehydrate,
+  createPersistor,
+  createTransform,
+  getStoredState,
+  persistStore,
+  purgeStoredState
 };

--- a/src/operators.js
+++ b/src/operators.js
@@ -1,0 +1,15 @@
+import { Map } from 'immutable';
+
+export const _stateInit = new Map();
+
+export function _stateIterator(state, callback) {
+  return state.forEach(callback);
+}
+
+export function _stateGetter(state, key) {
+ return state.get(key);
+};
+
+export function _stateSetter(state, key, value) {
+ return state.set(key, value);
+};

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -1,0 +1,28 @@
+import { Map } from 'immutable';
+
+export function stateReconciler(state, inboundState, reducedState, logger) {
+ let newState = reducedState ? reducedState : new Map();
+
+ Object.keys(inboundState).forEach((key) => {
+   // if initialState does not have key, skip auto rehydration
+   if (!state.has(key)) return
+
+   // if reducer modifies substate, skip auto rehydration
+   if (state.get('key') !== reducedState.get('key')) {
+     if (logger) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
+     newState = newState.set(key, reducedState.get(key))
+     return
+   }
+
+   // otherwise take the inboundState
+   if (state.has(key)) {
+     newState = state.merge(inboundState) // shallow merge
+   } else {
+     newState = state.set(key, inboundState[key]) // hard set
+   }
+
+   if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
+ })
+
+ return newState
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,24 @@
+import test from 'ava'
+
+import { autoRehydrate, persistStore } from '../lib'
+import { REHYDRATE } from '../lib/constants'
+
+import { compose, createStore } from 'redux'
+import { Map } from 'immutable'
+
+const rehydrate = (payload) => ({type: REHYDRATE, payload})
+const createReducer = () => {
+  return (state = Map({foo: 'fooVal', bar: [1, 2, 3]}), action) => {
+    return state
+  }
+}
+
+var finalCreateStore = compose(autoRehydrate())(createStore)
+
+test('Restores Immutable Map', (t) => {
+  let store = finalCreateStore(createReducer())
+  store.dispatch(rehydrate({foo: 'newVal'}))
+  let state = store.getState()
+  console.log('new state', state)
+  t.deepEqual(state.get('foo'), 'newVal')
+})


### PR DESCRIPTION
- proxies through all 7 redux-persist exports
- merges in immutable config for createPersistor, persistStore, and autoRehydrate

notes:
- I added one overly basic test, so this could definitely use more testing both of the automated and manual variety. 
- I recommend we rename this project to `redux-persist-immutable`
- It feels like REHYDRATE should fire with an immutable map, but to achieve this we would need to add yet another state operator to createPersistor config. Not sure...
